### PR TITLE
Add validation for `subjectActions`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Simple gitignore from https://github.com/github/gitignore/blob/main/Go.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Cloud-eCHISUtils
+
+The eCHIS project uses [CommCare Cosync](https://simprints.gitbook.io/docs/development/simprints-for-developers/other-intergrations/commcare-integration/cosync).
+This repository contains utilities that help CoSync function smoothly.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 The eCHIS project uses [CommCare Cosync](https://simprints.gitbook.io/docs/development/simprints-for-developers/other-intergrations/commcare-integration/cosync).
 This repository contains utilities that help CoSync function smoothly.
+
+## subjectactions
+
+This is a utility to check that the `subjectActions` field by Simprints ID to CommCare is valid.
+Look at the [subjectactions README](./subjectactions/README.md) for more details.

--- a/subjectactions/README.md
+++ b/subjectactions/README.md
@@ -1,0 +1,11 @@
+# subjectactions
+
+## Test
+
+Run `go test ./...`
+
+## Check `subjectActions` is valid
+
+The `subjectActions` field [passed by Simprints ID to CommCare](https://simprints.gitbook.io/docs/development/simprints-for-developers/other-intergrations/commcare-integration/cosync#saving-the-biometric-data) can be validated by the code provided in this package.
+
+Look at the documentation of `subjectactions.Check(input string)` for more details.

--- a/subjectactions/README.md
+++ b/subjectactions/README.md
@@ -1,5 +1,13 @@
 # subjectactions
 
+## Install the Go library
+
+Run the following command
+
+```shell
+go get github.com/simprints/cloud-echisutils/subjectactions
+```
+
 ## Test
 
 Run `go test ./...`

--- a/subjectactions/go.mod
+++ b/subjectactions/go.mod
@@ -1,0 +1,3 @@
+module github.com/simprints/cloud-echisutils/subjectactions
+
+go 1.24.2

--- a/subjectactions/go.mod
+++ b/subjectactions/go.mod
@@ -1,3 +1,11 @@
 module github.com/simprints/cloud-echisutils/subjectactions
 
 go 1.24.2
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/subjectactions/go.sum
+++ b/subjectactions/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/subjectactions/pkg/subjectactions/example_test.go
+++ b/subjectactions/pkg/subjectactions/example_test.go
@@ -1,0 +1,27 @@
+package subjectactions
+
+import (
+	"fmt"
+	"log"
+)
+
+func ExampleCheck() {
+	input := `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`
+	got, err := Check(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Subject ID: %s, Project ID: %s, (Tokenized) Module ID: %s, (Tokenized) Attendant ID: %s\n", got.SubjectID, got.ProjectID, got.TokenizedModuleID, got.TokenizedAtendantID)
+	// Output:
+	// Subject ID: aSubjectID, Project ID: aProjectID, (Tokenized) Module ID: aTokenizedModuleID, (Tokenized) Attendant ID: aTokenizedAttendantID
+}
+
+func ExampleCheck_error() {
+	input := ""
+	_, err := Check(input)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+	// Output:
+	// Error: input is empty
+}

--- a/subjectactions/pkg/subjectactions/subjectactions.go
+++ b/subjectactions/pkg/subjectactions/subjectactions.go
@@ -11,49 +11,49 @@ import (
 // It returns a non-nil error when the input string is invalid.
 func Check(input string) (SubjectSpecification, error) {
 	if len(input) == 0 {
-		return SubjectSpecification{}, errors.New("input is empty")
+		return SubjectSpecification{}, SubjectActionsError{Detail: "input is empty"}
 	}
 
 	var sidEvents SIDEvents
 	if err := json.Unmarshal([]byte(input), &sidEvents); err != nil {
-		return SubjectSpecification{}, errors.Join(errors.New("could not unmarshal input into SIDEvents"), err)
+		return SubjectSpecification{}, errors.Join(SubjectActionsError{Detail: "could not unmarshal input into SIDEvents"}, err)
 	}
 	if len(sidEvents.Events) != 1 {
-		return SubjectSpecification{}, fmt.Errorf("expect 1 event, got %d", len(sidEvents.Events))
+		return SubjectSpecification{}, SubjectActionsError{Field: "events", Detail: fmt.Sprintf("expect length 1, got %d", len(sidEvents.Events))}
 	}
-	if sidEvents.Events[0].Type != RequiredSIDEventType {
-		return SubjectSpecification{}, fmt.Errorf("expect event type %s event, got %s", RequiredSIDEventType, sidEvents.Events[0].Type)
+	if sidEvents.Events[0].Type != requiredSIDEventType {
+		return SubjectSpecification{}, SubjectActionsError{Field: "events[0].type", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDEventType, sidEvents.Events[0].Type)}
 	}
 
 	payload := sidEvents.Events[0].Payload
 	if len(payload.SubjectID) == 0 {
-		return SubjectSpecification{}, errors.New("empty subjectId")
+		return SubjectSpecification{}, SubjectActionsError{Field: "subjectId", Detail: "empty"}
 	}
 	if len(payload.ProjectID) == 0 {
-		return SubjectSpecification{}, errors.New("empty projectId")
+		return SubjectSpecification{}, SubjectActionsError{Field: "projectId", Detail: "empty"}
 	}
-	if payload.ModuleID.ClassName != RequiredStringValueClassName {
-		return SubjectSpecification{}, fmt.Errorf("expect moduleId to have className %s but got %s", RequiredStringValueClassName, payload.ModuleID.ClassName)
+	if payload.ModuleID.ClassName != requiredStringValueClassName {
+		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.className", Detail: fmt.Sprintf("expect %s, got %s", requiredStringValueClassName, payload.ModuleID.ClassName)}
 	}
 	if len(payload.ModuleID.Value) == 0 {
-		return SubjectSpecification{}, errors.New("empty moduleId")
+		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.value", Detail: "empty"}
 	}
-	if payload.AttendantID.ClassName != RequiredStringValueClassName {
-		return SubjectSpecification{}, fmt.Errorf("expect attendantId to have className %s but got %s", RequiredStringValueClassName, payload.AttendantID.ClassName)
+	if payload.AttendantID.ClassName != requiredStringValueClassName {
+		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.className", Detail: fmt.Sprintf("expect %s, got %s", requiredStringValueClassName, payload.AttendantID.ClassName)}
 	}
 	if len(payload.AttendantID.Value) == 0 {
-		return SubjectSpecification{}, errors.New("empty attendantId")
+		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.value", Detail: "empty"}
 	}
 
 	if len(payload.BiometricReferences) != 1 {
-		return SubjectSpecification{}, fmt.Errorf("expect 1 biometric reference, but got %d", len(payload.BiometricReferences))
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences", Detail: fmt.Sprintf("expect length 1, got %d", len(payload.BiometricReferences))}
 	}
 	reference := payload.BiometricReferences[0]
-	if reference.Type != RequiredSIDBiometricReferenceType {
-		return SubjectSpecification{}, fmt.Errorf("expect biometric reference type %s, got %s", RequiredSIDBiometricReferenceType, reference.Type)
+	if reference.Type != requiredSIDBiometricReferenceType {
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].type", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDBiometricReferenceType, reference.Type)}
 	}
-	if reference.Format != RequiredSIDBiometricReferenceFormat {
-		return SubjectSpecification{}, fmt.Errorf("expect biometric reference format %s, got %s", RequiredSIDBiometricReferenceFormat, reference.Format)
+	if reference.Format != requiredSIDBiometricReferenceFormat {
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].format", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDBiometricReferenceFormat, reference.Format)}
 	}
 
 	subjectSpecification := SubjectSpecification{
@@ -77,6 +77,81 @@ type SubjectSpecification struct {
 	TokenizedAtendantID string
 }
 
+// SubjectActionsError stores details about the way in which a given input failed to pass `Check()`.
+type SubjectActionsError struct {
+	// Detail contains information about what was wrong.
+	Detail string
+	// Field contains information about which field had something wrong if it is non-empty.
+	Field string
+}
+
+// Error makes SubjectActionsError implement error.
+func (e SubjectActionsError) Error() string {
+	if e.Field == "" {
+		return e.Detail
+	}
+	return fmt.Sprintf("%s: %s", e.Field, e.Detail)
+}
+
+// SIDEvents represents a collection of events generated by Simprints ID.
+type SIDEvents struct {
+	Events []SIDEvent `json:"events"`
+}
+
+// SIDEvent represents a single event generated by Simprints ID.
+type SIDEvent struct {
+	// ID is the unique ID of this event.
+	ID string `json:"id"`
+	// Type is the kind of event this is (in our case, this should always be EnrolmentRecordCreation).
+	Type string `json:"type"`
+	// Payload for an EnrolmentRecordCreation event is the data associated with the creation of an enrloment record in SID.
+	Payload SIDEnrolmentRecordCreationPayload `json:"payload"`
+}
+
+// Look at https://simprints.gitbook.io/docs/development/simprints-for-developers/other-intergrations/commcare-integration/cosync for more documentation of SID <> CommCare integration
+type SIDEnrolmentRecordCreationPayload struct {
+	/// SubjectID is the ID of the person (a.k.a 'subject') this enrolment record belongs to, and is the same as `simprintsId` or `guid` in the integration.
+	SubjectID string `json:"subjectId"`
+	// ProjectID is the ID of the Simprints project this enrolment record belongs to, and is the same as `projectId` used in integration.
+	ProjectID string `json:"projectId"`
+	// ModuleID is the ID of the Simprints module this enrolment record belongs to, and is the same as `moduleId` used in integration.
+	ModuleID StringValue `json:"moduleId"`
+	// AttendantID is the ID of the attendant (a.k.a 'user') that enrolled this subject, and is the same as `userId` used in integration.
+	AttendantID StringValue `json:"attendantId"`
+	// BiometricReferences contains all biometric data attached to this subject.
+	BiometricReferences []SIDBiometricReference `json:"biometricReferences"`
+}
+
+// StringValue is a struct that a potentially tokenized (encrypted) string.
+type StringValue struct {
+	// ClassName is "TokenizableString.Tokenized" when the string is tokenized and "TokenizableString.Raw" when not.
+	ClassName string `json:"className"`
+	// Value is the actual tokenized or raw string (depending on what ClassName is).
+	Value string `json:"value"`
+}
+
+// SIDBiometricReference represents a particular kind of biometric data.
+type SIDBiometricReference struct {
+	// ID is the unique ID of this biometric reference.
+	ID string `json:"id"`
+	// Templates is a collection of biometric templates that make up this biometric reference (in our case, just fingerprint templates).
+	Templates []SIDTemplate `json:"templates"`
+	// Format is the format of the biometric templates (in our case, just "ISO_19794_2").
+	Format string `json:"format"`
+	// Type is the biometric modality of this biometric reference (in our case, just 'FINGERPRINT_REFERENCE').
+	Type string `json:"type"`
+}
+
+// SIDTemplate represents a single biometric template.
+type SIDTemplate struct {
+	// Quality is the biometric quality of the template (the higher the quality, the better).
+	Quality float64 `json:"quality"`
+	// Template is the base64 encoded biometric template data.
+	Template string `json:"template"`
+	// Finger represents which finger this biometric template corresponds to (e.g. RIGHT_THUMB).
+	Finger string `json:"finger"`
+}
+
 // SID expects the following schema (where '*' denotes some array index)
 // For this project, we expect only 1 EnrolmentRecordCreation event.
 // For this project, we only expect ISO templates for the fingerprint modality.
@@ -97,44 +172,8 @@ type SubjectSpecification struct {
 // > events.*.payload.biometricReferences.*.templates.*.template
 
 const (
-	RequiredSIDEventType                = "EnrolmentRecordCreation"
-	RequiredStringValueClassName        = "TokenizableString.Tokenized"
-	RequiredSIDBiometricReferenceType   = "FINGERPRINT_REFERENCE"
-	RequiredSIDBiometricReferenceFormat = "ISO_19794_2"
+	requiredSIDEventType                = "EnrolmentRecordCreation"
+	requiredStringValueClassName        = "TokenizableString.Tokenized"
+	requiredSIDBiometricReferenceType   = "FINGERPRINT_REFERENCE"
+	requiredSIDBiometricReferenceFormat = "ISO_19794_2"
 )
-
-type SIDEvents struct {
-	Events []SIDEvent `json:"events"`
-}
-
-type SIDEvent struct {
-	ID      string                            `json:"id"`
-	Type    string                            `json:"type"`
-	Payload SIDEnrolmentRecordCreationPayload `json:"payload"`
-}
-
-type SIDEnrolmentRecordCreationPayload struct {
-	SubjectID           string                  `json:"subjectId"`
-	ProjectID           string                  `json:"projectId"`
-	ModuleID            StringValue             `json:"moduleId"`
-	AttendantID         StringValue             `json:"attendantId"`
-	BiometricReferences []SIDBiometricReference `json:"biometricReferences"`
-}
-
-type StringValue struct {
-	ClassName string `json:"className"`
-	Value     string `json:"value"`
-}
-
-type SIDBiometricReference struct {
-	ID        string        `json:"id"`
-	Templates []SIDTemplate `json:"templates"`
-	Format    string        `json:"format"`
-	Type      string        `json:"type"`
-}
-
-type SIDTemplate struct {
-	Quality  float64 `json:"quality"`
-	Template string  `json:"template"`
-	Finger   string  `json:"finger"`
-}

--- a/subjectactions/pkg/subjectactions/subjectactions.go
+++ b/subjectactions/pkg/subjectactions/subjectactions.go
@@ -104,7 +104,7 @@ type SIDEvent struct {
 	ID string `json:"id"`
 	// Type is the kind of event this is (in our case, this should always be EnrolmentRecordCreation).
 	Type string `json:"type"`
-	// Payload for an EnrolmentRecordCreation event is the data associated with the creation of an enrloment record in SID.
+	// Payload for an EnrolmentRecordCreation event is the data associated with the creation of an enrolment record in SID.
 	Payload SIDEnrolmentRecordCreationPayload `json:"payload"`
 }
 

--- a/subjectactions/pkg/subjectactions/subjectactions.go
+++ b/subjectactions/pkg/subjectactions/subjectactions.go
@@ -19,41 +19,41 @@ func Check(input string) (SubjectSpecification, error) {
 		return SubjectSpecification{}, errors.Join(SubjectActionsError{Detail: "could not unmarshal input into SIDEvents"}, err)
 	}
 	if len(sidEvents.Events) != 1 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "events", Detail: fmt.Sprintf("expect length 1, got %d", len(sidEvents.Events))}
+		return SubjectSpecification{}, SubjectActionsError{Field: "events", Detail: errorDetailUnexpectedLength(1, len(sidEvents.Events))}
 	}
 	if sidEvents.Events[0].Type != requiredSIDEventType {
-		return SubjectSpecification{}, SubjectActionsError{Field: "events[0].type", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDEventType, sidEvents.Events[0].Type)}
+		return SubjectSpecification{}, SubjectActionsError{Field: "events[0].type", Detail: errorDetailUnexpectedField(requiredSIDEventType, sidEvents.Events[0].Type)}
 	}
 
 	payload := sidEvents.Events[0].Payload
 	if len(payload.SubjectID) == 0 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "subjectId", Detail: "empty"}
+		return SubjectSpecification{}, SubjectActionsError{Field: "subjectId", Detail: errorDetailEmptyField}
 	}
 	if len(payload.ProjectID) == 0 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "projectId", Detail: "empty"}
+		return SubjectSpecification{}, SubjectActionsError{Field: "projectId", Detail: errorDetailEmptyField}
 	}
 	if payload.ModuleID.ClassName != requiredStringValueClassName {
-		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.className", Detail: fmt.Sprintf("expect %s, got %s", requiredStringValueClassName, payload.ModuleID.ClassName)}
+		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.className", Detail: errorDetailUnexpectedField(requiredStringValueClassName, payload.ModuleID.ClassName)}
 	}
 	if len(payload.ModuleID.Value) == 0 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.value", Detail: "empty"}
+		return SubjectSpecification{}, SubjectActionsError{Field: "moduleId.value", Detail: errorDetailEmptyField}
 	}
 	if payload.AttendantID.ClassName != requiredStringValueClassName {
-		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.className", Detail: fmt.Sprintf("expect %s, got %s", requiredStringValueClassName, payload.AttendantID.ClassName)}
+		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.className", Detail: errorDetailUnexpectedField(requiredStringValueClassName, payload.AttendantID.ClassName)}
 	}
 	if len(payload.AttendantID.Value) == 0 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.value", Detail: "empty"}
+		return SubjectSpecification{}, SubjectActionsError{Field: "attendantId.value", Detail: errorDetailEmptyField}
 	}
 
 	if len(payload.BiometricReferences) != 1 {
-		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences", Detail: fmt.Sprintf("expect length 1, got %d", len(payload.BiometricReferences))}
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences", Detail: errorDetailUnexpectedLength(1, len(payload.BiometricReferences))}
 	}
 	reference := payload.BiometricReferences[0]
 	if reference.Type != requiredSIDBiometricReferenceType {
-		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].type", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDBiometricReferenceType, reference.Type)}
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].type", Detail: errorDetailUnexpectedField(requiredSIDBiometricReferenceType, reference.Type)}
 	}
 	if reference.Format != requiredSIDBiometricReferenceFormat {
-		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].format", Detail: fmt.Sprintf("expect %s, got %s", requiredSIDBiometricReferenceFormat, reference.Format)}
+		return SubjectSpecification{}, SubjectActionsError{Field: "biometricReferences[0].format", Detail: errorDetailUnexpectedField(requiredSIDBiometricReferenceFormat, reference.Format)}
 	}
 
 	subjectSpecification := SubjectSpecification{
@@ -177,3 +177,15 @@ const (
 	requiredSIDBiometricReferenceType   = "FINGERPRINT_REFERENCE"
 	requiredSIDBiometricReferenceFormat = "ISO_19794_2"
 )
+
+const (
+	errorDetailEmptyField = "empty field"
+)
+
+func errorDetailUnexpectedField(expected string, got string) string {
+	return fmt.Sprintf("expect %s, got %s", expected, got)
+}
+
+func errorDetailUnexpectedLength(expected int, got int) string {
+	return fmt.Sprintf("expect length %d, got %d", expected, got)
+}

--- a/subjectactions/pkg/subjectactions/subjectactions.go
+++ b/subjectactions/pkg/subjectactions/subjectactions.go
@@ -1,0 +1,140 @@
+package subjectactions
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Check is a simple utility function that checks the given input string is a valid subjectActions that can be parsed by SID.
+// It returns a SubjectSpecification for the subject and a nil error if the input string is valid.
+// It returns a non-nil error when the input string is invalid.
+func Check(input string) (SubjectSpecification, error) {
+	if len(input) == 0 {
+		return SubjectSpecification{}, errors.New("input is empty")
+	}
+
+	var sidEvents SIDEvents
+	if err := json.Unmarshal([]byte(input), &sidEvents); err != nil {
+		return SubjectSpecification{}, errors.Join(errors.New("could not unmarshal input into SIDEvents"), err)
+	}
+	if len(sidEvents.Events) != 1 {
+		return SubjectSpecification{}, fmt.Errorf("expect 1 event, got %d", len(sidEvents.Events))
+	}
+	if sidEvents.Events[0].Type != RequiredSIDEventType {
+		return SubjectSpecification{}, fmt.Errorf("expect event type %s event, got %s", RequiredSIDEventType, sidEvents.Events[0].Type)
+	}
+
+	payload := sidEvents.Events[0].Payload
+	if len(payload.SubjectID) == 0 {
+		return SubjectSpecification{}, errors.New("empty subjectId")
+	}
+	if len(payload.ProjectID) == 0 {
+		return SubjectSpecification{}, errors.New("empty projectId")
+	}
+	if payload.ModuleID.ClassName != RequiredStringValueClassName {
+		return SubjectSpecification{}, fmt.Errorf("expect moduleId to have className %s but got %s", RequiredStringValueClassName, payload.ModuleID.ClassName)
+	}
+	if len(payload.ModuleID.Value) == 0 {
+		return SubjectSpecification{}, errors.New("empty moduleId")
+	}
+	if payload.AttendantID.ClassName != RequiredStringValueClassName {
+		return SubjectSpecification{}, fmt.Errorf("expect attendantId to have className %s but got %s", RequiredStringValueClassName, payload.AttendantID.ClassName)
+	}
+	if len(payload.AttendantID.Value) == 0 {
+		return SubjectSpecification{}, errors.New("empty attendantId")
+	}
+
+	if len(payload.BiometricReferences) != 1 {
+		return SubjectSpecification{}, fmt.Errorf("expect 1 biometric reference, but got %d", len(payload.BiometricReferences))
+	}
+	reference := payload.BiometricReferences[0]
+	if reference.Type != RequiredSIDBiometricReferenceType {
+		return SubjectSpecification{}, fmt.Errorf("expect biometric reference type %s, got %s", RequiredSIDBiometricReferenceType, reference.Type)
+	}
+	if reference.Format != RequiredSIDBiometricReferenceFormat {
+		return SubjectSpecification{}, fmt.Errorf("expect biometric reference format %s, got %s", RequiredSIDBiometricReferenceFormat, reference.Format)
+	}
+
+	subjectSpecification := SubjectSpecification{
+		SubjectID:           payload.SubjectID,
+		ProjectID:           payload.ProjectID,
+		TokenizedModuleID:   payload.ModuleID.Value,
+		TokenizedAtendantID: payload.AttendantID.Value,
+	}
+	return subjectSpecification, nil
+}
+
+// SubjectSpecification contains details for a given subject.
+type SubjectSpecification struct {
+	// SubjectID is the ID of the subject.
+	SubjectID string
+	// ProjectID is the ID of the Simprints project.
+	ProjectID string
+	// TokenizedModuleID is the tokenized (encrypted) version of the Simprints module ID, but it has not been validated.
+	TokenizedModuleID string
+	// TokenizedAttendantID is the tokenized (encrypted) version of the Simprints attendant ID, but it has not been validated.
+	TokenizedAtendantID string
+}
+
+// SID expects the following schema (where '*' denotes some array index)
+// For this project, we expect only 1 EnrolmentRecordCreation event.
+// For this project, we only expect ISO templates for the fingerprint modality.
+//
+// > events.*.id
+// > events.*.type (must always be 'EnrolmentRecordCreation')
+// > events.*.payload.projectId
+// > events.*.payload.subjectId
+// > events.*.payload.moduleId.className (should be 'TokenizableString.Tokenized')
+// > events.*.payload.moduleId.value (this field should be tokenized)
+// > events.*.payload.attendantId.className (should be 'TokenizableString.Tokenized')
+// > events.*.payload.attendantId.value (this field should be tokenized)
+// > events.*.payload.biometricReferences.*.format (must always be 'ISO_19794_2')
+// > events.*.payload.biometricReferences.*.id
+// > events.*.payload.biometricReferences.*.type (must always be 'FINGERPRINT_REFERENCE')
+// > events.*.payload.biometricReferences.*.templates.*.finger
+// > events.*.payload.biometricReferences.*.templates.*.quality
+// > events.*.payload.biometricReferences.*.templates.*.template
+
+const (
+	RequiredSIDEventType                = "EnrolmentRecordCreation"
+	RequiredStringValueClassName        = "TokenizableString.Tokenized"
+	RequiredSIDBiometricReferenceType   = "FINGERPRINT_REFERENCE"
+	RequiredSIDBiometricReferenceFormat = "ISO_19794_2"
+)
+
+type SIDEvents struct {
+	Events []SIDEvent `json:"events"`
+}
+
+type SIDEvent struct {
+	ID      string                            `json:"id"`
+	Type    string                            `json:"type"`
+	Payload SIDEnrolmentRecordCreationPayload `json:"payload"`
+}
+
+type SIDEnrolmentRecordCreationPayload struct {
+	SubjectID           string                  `json:"subjectId"`
+	ProjectID           string                  `json:"projectId"`
+	ModuleID            StringValue             `json:"moduleId"`
+	AttendantID         StringValue             `json:"attendantId"`
+	BiometricReferences []SIDBiometricReference `json:"biometricReferences"`
+}
+
+type StringValue struct {
+	ClassName string `json:"className"`
+	Value     string `json:"value"`
+}
+
+type SIDBiometricReference struct {
+	ID        string        `json:"id"`
+	Templates []SIDTemplate `json:"templates"`
+	Format    string        `json:"format"`
+	Type      string        `json:"type"`
+}
+
+type SIDTemplate struct {
+	Quality  float64 `json:"quality"`
+	Template string  `json:"template"`
+	Finger   string  `json:"finger"`
+}

--- a/subjectactions/pkg/subjectactions/subjectactions_test.go
+++ b/subjectactions/pkg/subjectactions/subjectactions_test.go
@@ -35,7 +35,7 @@ func TestCheck(t *testing.T) {
 		{
 			name:              "wrong event type should return error",
 			input:             `{"events": [{"id": "anID", "type": "WrongEventType", "payload": {}}]}`,
-			expectedErrPrefix: "expect event type",
+			expectedErrPrefix: "expect event type EnrolmentRecordCreation",
 		},
 		{
 			name:              "empty subjectId should return error",
@@ -50,7 +50,7 @@ func TestCheck(t *testing.T) {
 		{
 			name:              "wrong moduleId className should return error",
 			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"wrong","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect moduleId to have className",
+			expectedErrPrefix: "expect moduleId to have className TokenizableString.Tokenized",
 		},
 		{
 			name:              "empty moduleId should return error",
@@ -60,7 +60,7 @@ func TestCheck(t *testing.T) {
 		{
 			name:              "wrong attendantID className should return error",
 			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"wrong","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect attendantId to have className",
+			expectedErrPrefix: "expect attendantId to have className TokenizableString.Tokenized",
 		},
 		{
 			name:              "empty attendantId should return error",
@@ -80,12 +80,12 @@ func TestCheck(t *testing.T) {
 		{
 			name:              "wrong biometric reference type should return error",
 			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"WRONG_TYPE"}]}}]}`,
-			expectedErrPrefix: "expect biometric reference type",
+			expectedErrPrefix: "expect biometric reference type FINGERPRINT_REFERENCE",
 		},
 		{
 			name:              "wrong biometric reference format should return error",
 			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"WRONG_FORMAT","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect biometric reference format",
+			expectedErrPrefix: "expect biometric reference format ISO_19794_2",
 		},
 		{
 			name:              "valid input should return the correct subject specification",

--- a/subjectactions/pkg/subjectactions/subjectactions_test.go
+++ b/subjectactions/pkg/subjectactions/subjectactions_test.go
@@ -1,116 +1,117 @@
 package subjectactions
 
 import (
-	"strings"
+	"fmt"
+	"log"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheck(t *testing.T) {
-	tcs := []struct {
-		name              string
-		input             string
-		expectedErrPrefix string
-		expectedResult    SubjectSpecification
+	tcs := map[string]struct {
+		input          string
+		expectedErr    string
+		expectedResult SubjectSpecification
 	}{
-		{
-			name:              "empty string should return error",
-			input:             "",
-			expectedErrPrefix: "input is empty",
+		"empty string should return error": {
+			input:       "",
+			expectedErr: "input is empty",
 		},
-		{
-			name:              "invalid json should return error",
-			input:             "invalid json",
-			expectedErrPrefix: "could not unmarshal",
+		"invalid json should return error": {
+			input:       "invalid json",
+			expectedErr: "could not unmarshal input into SIDEvents",
 		},
-		{
-			name:              "empty events array should return error",
-			input:             `{"events": []}`,
-			expectedErrPrefix: "expect 1 event",
+		"empty events array should return error": {
+			input:       `{"events": []}`,
+			expectedErr: "events: expect length 1",
 		},
-		{
-			name:              "multiple events should return error",
-			input:             `{"events": [{}, {}]}`,
-			expectedErrPrefix: "expect 1 event",
+		"multiple events should return error": {
+			input:       `{"events": [{}, {}]}`,
+			expectedErr: "events: expect length 1",
 		},
-		{
-			name:              "wrong event type should return error",
-			input:             `{"events": [{"id": "anID", "type": "WrongEventType", "payload": {}}]}`,
-			expectedErrPrefix: "expect event type EnrolmentRecordCreation",
+		"wrong event type should return error": {
+			input:       `{"events": [{"id": "anID", "type": "WrongEventType", "payload": {}}]}`,
+			expectedErr: "events[0].type: expect EnrolmentRecordCreation, got WrongEventType",
 		},
-		{
-			name:              "empty subjectId should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "empty subjectId",
+		"empty subjectId should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "subjectId: empty",
 		},
-		{
-			name:              "empty projectId should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "empty projectId",
+		"empty projectId should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "projectId: empty",
 		},
-		{
-			name:              "wrong moduleId className should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"wrong","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect moduleId to have className TokenizableString.Tokenized",
+		"wrong moduleId className should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"wrong","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "moduleId.className: expect TokenizableString.Tokenized, got wrong",
 		},
-		{
-			name:              "empty moduleId should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":""},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "empty moduleId",
+		"empty moduleId should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":""},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "moduleId.value: empty",
 		},
-		{
-			name:              "wrong attendantID className should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"wrong","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect attendantId to have className TokenizableString.Tokenized",
+		"wrong attendantID className should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"wrong","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "attendantId.className: expect TokenizableString.Tokenized, got wrong",
 		},
-		{
-			name:              "empty attendantId should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":""},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "empty attendantId",
+		"empty attendantId should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":""},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "attendantId.value: empty",
 		},
-		{
-			name:              "empty biometric references should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect 1 biometric reference",
+		"empty biometric references should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "biometricReferences: expect length 1",
 		},
-		{
-			name:              "multiple biometric references should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect 1 biometric reference",
+		"multiple biometric references should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "biometricReferences: expect length 1",
 		},
-		{
-			name:              "wrong biometric reference type should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"WRONG_TYPE"}]}}]}`,
-			expectedErrPrefix: "expect biometric reference type FINGERPRINT_REFERENCE",
+		"wrong biometric reference type should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"WRONG_TYPE"}]}}]}`,
+			expectedErr: "biometricReferences[0].type: expect FINGERPRINT_REFERENCE, got WRONG_TYPE",
 		},
-		{
-			name:              "wrong biometric reference format should return error",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"WRONG_FORMAT","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "expect biometric reference format ISO_19794_2",
+		"wrong biometric reference format should return error": {
+			input:       `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"WRONG_FORMAT","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr: "biometricReferences[0].format: expect ISO_19794_2, got WRONG_FORMAT",
 		},
-		{
-			name:              "valid input should return the correct subject specification",
-			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
-			expectedErrPrefix: "",
-			expectedResult:    SubjectSpecification{SubjectID: "aSubjectID", ProjectID: "aProjectID", TokenizedModuleID: "aModuleID", TokenizedAtendantID: "anAttendantID"},
+		"valid input should return the correct subject specification": {
+			input:          `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErr:    "",
+			expectedResult: SubjectSpecification{SubjectID: "aSubjectID", ProjectID: "aProjectID", TokenizedModuleID: "aTokenizedModuleID", TokenizedAtendantID: "aTokenizedAttendantID"},
 		},
 	}
 
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := Check(tc.input)
-			if err != nil {
-				if !strings.HasPrefix(err.Error(), tc.expectedErrPrefix) {
-					t.Errorf("error got '%s', expectedErrPrefix '%v'", err.Error(), tc.expectedErrPrefix)
-				}
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
 				return
 			}
-			if tc.expectedErrPrefix != "" {
-				t.Errorf("error got nil, expectedErrPrefix %v", tc.expectedErrPrefix)
-			}
-			if got != tc.expectedResult {
-				t.Errorf("result got %v, expected %v", got, tc.expectedResult)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, got)
 		})
 	}
+}
+
+func ExampleCheck() {
+	input := `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`
+	got, err := Check(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Subject ID: %s, Project ID: %s, (Tokenized) Module ID: %s, (Tokenized) Attendant ID: %s\n", got.SubjectID, got.ProjectID, got.TokenizedModuleID, got.TokenizedAtendantID)
+	// Output:
+	// Subject ID: aSubjectID, Project ID: aProjectID, (Tokenized) Module ID: aTokenizedModuleID, (Tokenized) Attendant ID: aTokenizedAttendantID
+}
+
+func ExampleCheck_error() {
+	input := ""
+	_, err := Check(input)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+	// Output:
+	// Error: input is empty
 }

--- a/subjectactions/pkg/subjectactions/subjectactions_test.go
+++ b/subjectactions/pkg/subjectactions/subjectactions_test.go
@@ -1,8 +1,6 @@
 package subjectactions
 
 import (
-	"fmt"
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,25 +91,4 @@ func TestCheck(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, got)
 		})
 	}
-}
-
-func ExampleCheck() {
-	input := `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aTokenizedModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"aTokenizedAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`
-	got, err := Check(input)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Subject ID: %s, Project ID: %s, (Tokenized) Module ID: %s, (Tokenized) Attendant ID: %s\n", got.SubjectID, got.ProjectID, got.TokenizedModuleID, got.TokenizedAtendantID)
-	// Output:
-	// Subject ID: aSubjectID, Project ID: aProjectID, (Tokenized) Module ID: aTokenizedModuleID, (Tokenized) Attendant ID: aTokenizedAttendantID
-}
-
-func ExampleCheck_error() {
-	input := ""
-	_, err := Check(input)
-	if err != nil {
-		fmt.Println("Error:", err)
-	}
-	// Output:
-	// Error: input is empty
 }

--- a/subjectactions/pkg/subjectactions/subjectactions_test.go
+++ b/subjectactions/pkg/subjectactions/subjectactions_test.go
@@ -1,0 +1,116 @@
+package subjectactions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	tcs := []struct {
+		name              string
+		input             string
+		expectedErrPrefix string
+		expectedResult    SubjectSpecification
+	}{
+		{
+			name:              "empty string should return error",
+			input:             "",
+			expectedErrPrefix: "input is empty",
+		},
+		{
+			name:              "invalid json should return error",
+			input:             "invalid json",
+			expectedErrPrefix: "could not unmarshal",
+		},
+		{
+			name:              "empty events array should return error",
+			input:             `{"events": []}`,
+			expectedErrPrefix: "expect 1 event",
+		},
+		{
+			name:              "multiple events should return error",
+			input:             `{"events": [{}, {}]}`,
+			expectedErrPrefix: "expect 1 event",
+		},
+		{
+			name:              "wrong event type should return error",
+			input:             `{"events": [{"id": "anID", "type": "WrongEventType", "payload": {}}]}`,
+			expectedErrPrefix: "expect event type",
+		},
+		{
+			name:              "empty subjectId should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "empty subjectId",
+		},
+		{
+			name:              "empty projectId should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "empty projectId",
+		},
+		{
+			name:              "wrong moduleId className should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"wrong","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "expect moduleId to have className",
+		},
+		{
+			name:              "empty moduleId should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":""},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "empty moduleId",
+		},
+		{
+			name:              "wrong attendantID className should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"wrong","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "expect attendantId to have className",
+		},
+		{
+			name:              "empty attendantId should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":""},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "empty attendantId",
+		},
+		{
+			name:              "empty biometric references should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "expect 1 biometric reference",
+		},
+		{
+			name:              "multiple biometric references should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"},{"id":"anotherBiometricReferenceID","templates":[{"finger":"LEFT_THUMB","quality":0.9,"template":"anotherTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "expect 1 biometric reference",
+		},
+		{
+			name:              "wrong biometric reference type should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"WRONG_TYPE"}]}}]}`,
+			expectedErrPrefix: "expect biometric reference type",
+		},
+		{
+			name:              "wrong biometric reference format should return error",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"WRONG_FORMAT","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "expect biometric reference format",
+		},
+		{
+			name:              "valid input should return the correct subject specification",
+			input:             `{"events": [{"id": "anID", "type": "EnrolmentRecordCreation", "payload": {"subjectId":"aSubjectID","projectId":"aProjectID","moduleId":{"className":"TokenizableString.Tokenized","value":"aModuleID"},"attendantId":{"className":"TokenizableString.Tokenized","value":"anAttendantID"},"biometricReferences":[{"id":"aBiometricReferenceID","templates":[{"finger":"RIGHT_THUMB","quality":0.8,"template":"aTemplate"}],"format":"ISO_19794_2","type":"FINGERPRINT_REFERENCE"}]}}]}`,
+			expectedErrPrefix: "",
+			expectedResult:    SubjectSpecification{SubjectID: "aSubjectID", ProjectID: "aProjectID", TokenizedModuleID: "aModuleID", TokenizedAtendantID: "anAttendantID"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Check(tc.input)
+			if err != nil {
+				if !strings.HasPrefix(err.Error(), tc.expectedErrPrefix) {
+					t.Errorf("error got '%s', expectedErrPrefix '%v'", err.Error(), tc.expectedErrPrefix)
+				}
+				return
+			}
+			if tc.expectedErrPrefix != "" {
+				t.Errorf("error got nil, expectedErrPrefix %v", tc.expectedErrPrefix)
+			}
+			if got != tc.expectedResult {
+				t.Errorf("result got %v, expected %v", got, tc.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is so that eCHIS can run the validation on biometric data they have in their database.
We return `SubjectID`, `ProjectID`, `AttendantID` and `ModuleID` so that when we start receiving this data from CommCare we sanity check that the tokenized values make sense, and also have some information about what records do not pass the validation check.